### PR TITLE
Sample clean-ups, replace all compose-shadow references

### DIFF
--- a/phosphor/build.gradle.kts
+++ b/phosphor/build.gradle.kts
@@ -74,7 +74,7 @@ mavenPublishing {
     )
     pom {
         name.set("phosphor-icon")
-        description.set("a kotlin platform library for show drop shadow in compose.")
+        description.set("Phosphor Icons for Compose Multiplatform.")
         url.set("https://github.com/adamglin0/phosphor-icon")
         licenses {
             license {

--- a/sample/android-app/build.gradle.kts
+++ b/sample/android-app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 android {
-    namespace = "com.adamglin.composeshadow.android"
+    namespace = "com.adamglin.phosphoricons.android"
     compileSdk = libs.versions.androidCompileSdk.get().toInt()
     buildFeatures {
         buildConfig = false
@@ -15,8 +15,8 @@ android {
     }
     defaultConfig {
         minSdk = libs.versions.androidMinSdk.get().toInt()
-        lint.targetSdk = libs.versions.androidTargetSdk.get().toInt()
-        applicationId = "com.adamglin.composeshadow"
+        targetSdk = libs.versions.androidTargetSdk.get().toInt()
+        applicationId = "com.adamglin.phosphoricons"
         versionCode = 1
         versionName = "0.0.1"
 

--- a/sample/android-app/src/main/AndroidManifest.xml
+++ b/sample/android-app/src/main/AndroidManifest.xml
@@ -2,11 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
     <application
-        android:name="com.adamglin.composeshadow.android.SampleApplication"
+        android:name="com.adamglin.phosphoricons.android.SampleApplication"
         android:allowBackup="true"
         android:enableOnBackInvokedCallback="true"
         android:hardwareAccelerated="true"
@@ -16,9 +13,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar"
         android:usesCleartextTraffic="true"
-        tools:targetApi="31">
+        tools:targetApi="34">
+
         <activity
-            android:name="com.adamglin.composeshadow.android.MainActivity"
+            android:name="com.adamglin.phosphoricons.android.MainActivity"
             android:exported="true"
             android:label="@string/title_activity_main"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar">

--- a/sample/android-app/src/main/kotlin/com/adamglin/phosphoricons/android/MainActivity.kt
+++ b/sample/android-app/src/main/kotlin/com/adamglin/phosphoricons/android/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.adamglin.composeshadow.android
+package com.adamglin.phosphoricons.android
 
 import SampleApp
 import android.os.Bundle

--- a/sample/android-app/src/main/kotlin/com/adamglin/phosphoricons/android/SampleApplication.kt
+++ b/sample/android-app/src/main/kotlin/com/adamglin/phosphoricons/android/SampleApplication.kt
@@ -1,4 +1,4 @@
-package com.adamglin.composeshadow.android
+package com.adamglin.phosphoricons.android
 
 import android.app.Application
 import android.content.Context

--- a/sample/android-app/src/main/res/values/strings.xml
+++ b/sample/android-app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">compose shadow sample</string>
-    <string name="title_activity_main">sample</string>
+    <string name="app_name">Phosphor Icons Sample</string>
+    <string name="title_activity_main">Sample</string>
 </resources>

--- a/sample/desktop-app/build.gradle.kts
+++ b/sample/desktop-app/build.gradle.kts
@@ -23,7 +23,7 @@ compose.desktop {
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
-            packageName = "org.adamglin.composeshadow"
+            packageName = "org.adamglin.phosphoricons"
             packageVersion = "1.0.0"
         }
     }

--- a/sample/desktop-app/src/main/kotlin/main.kt
+++ b/sample/desktop-app/src/main/kotlin/main.kt
@@ -1,7 +1,4 @@
 import androidx.compose.ui.window.singleWindowApplication
-import kotlin.io.path.Path
-import kotlin.io.path.createDirectory
-
 
 fun main() {
     singleWindowApplication {

--- a/sample/ios-app/Configuration/Config.xcconfig
+++ b/sample/ios-app/Configuration/Config.xcconfig
@@ -1,3 +1,3 @@
 TEAM_ID=
-BUNDLE_ID=org.adamglin.composeshadow.ios
+BUNDLE_ID=org.adamglin.phosphoricons.ios
 APP_NAME=Sample

--- a/sample/shared/build.gradle.kts
+++ b/sample/shared/build.gradle.kts
@@ -44,7 +44,7 @@ kotlin {
 }
 
 android {
-    namespace = "com.adamglin.composeshadow.shared"
+    namespace = "com.adamglin.phosphoricons.shared"
     compileSdk = libs.versions.androidCompileSdk.get().toInt()
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")


### PR DESCRIPTION
Some general improvements to samples, along with replacement of old `compose-shadow` references.